### PR TITLE
Pin catalogsource to v2.0.6

### DIFF
--- a/charts/catalogsources/values.yaml
+++ b/charts/catalogsources/values.yaml
@@ -7,6 +7,6 @@ catalogsources:
     image:
       registry: quay.io
       repository: redhatgov/operator-catalog
-      version: latest
+      version: 2.0.6
 marketplace:
   namespace: openshift-marketplace


### PR DESCRIPTION
Upgrades the nexus operator to 0.0.11 which includes the fix to OOM kill of the JVM by increasing the heap memory to 512m by default. It is also possible to override the value in the nexus manifest.

This PR should be reverted once the `latest` tag in the catalog links to this version.

/assign @sabre1041 