### PR TITLE
Prevent pipelineRuns from being pruned

### DIFF
--- a/charts/rfe-pipelines/values.yaml
+++ b/charts/rfe-pipelines/values.yaml
@@ -7,4 +7,5 @@ defaultsConfigmap:
 commonCR:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    rgocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-wave: "5"


### PR DESCRIPTION
@sabre1041 take a look. I added this annotation to prevent argocd from pruning the `pipelinerun` pods.