### PR TITLE
Disable content-type validation in nexus

### DIFF
--- a/charts/nexus/templates/nexus-setup-job.yaml
+++ b/charts/nexus/templates/nexus-setup-job.yaml
@@ -49,7 +49,7 @@ spec:
                    -u "${NEXUS_ADMIN_USERNAME}:${NEXUS_ADMIN_PASSWORD}" \
                    -H "accept: application/json" \
                    -H "Content-Type: application/json" \
-                   -d "{ \"name\": \"${repository}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true, \"writePolicy\": \"ALLOW\" }}"
+                   -d "{ \"name\": \"${repository}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": false, \"writePolicy\": \"ALLOW\" }}"
 
                 fi
               done


### PR DESCRIPTION
@sabre1041 this is a quick fix for the content type issue. I'd consider it for now until we can figure out why the qcow2 file fails to upload (https://github.com/redhat-cop/rhel-edge-automation-arch/issues/183)